### PR TITLE
fix: 自動削除でdeleteAtを指定すると違う日時が指定される問題

### DIFF
--- a/packages/backend/src/core/NoteCreateService.ts
+++ b/packages/backend/src/core/NoteCreateService.ts
@@ -9,6 +9,7 @@ import { In, DataSource, IsNull, LessThan } from 'typeorm';
 import * as Redis from 'ioredis';
 import { Inject, Injectable, OnApplicationShutdown } from '@nestjs/common';
 import RE2 from 're2';
+import { Data } from 'ws';
 import { extractMentions } from '@/misc/extract-mentions.js';
 import { extractCustomEmojisFromMfm } from '@/misc/extract-custom-emojis-from-mfm.js';
 import { extractHashtags } from '@/misc/extract-hashtags.js';
@@ -61,7 +62,6 @@ import { UserBlockingService } from '@/core/UserBlockingService.js';
 import { isReply } from '@/misc/is-reply.js';
 import { trackPromise } from '@/misc/promise-tracker.js';
 import { IdentifiableError } from '@/misc/identifiable-error.js';
-import { Data } from 'ws';
 
 type NotificationType = 'reply' | 'renote' | 'quote' | 'mention';
 
@@ -515,7 +515,7 @@ export class NoteCreateService implements OnApplicationShutdown {
 					}
 
 					if (insert.visibility === 'private') {
-						insert.localOnly = true
+						insert.localOnly = true;
 					}
 				});
 			} else {
@@ -772,7 +772,6 @@ export class NoteCreateService implements OnApplicationShutdown {
 				}
 			});
 		}
-
 	}
 
 	@bindThis

--- a/packages/backend/src/server/api/endpoints/notes/create.ts
+++ b/packages/backend/src/server/api/endpoints/notes/create.ts
@@ -216,7 +216,7 @@ export const paramDef = {
 				deleteAfter: { type: 'integer', nullable: true, minimum: 1 },
 			},
 		},
-		searchableBy: { type: 'string', enum: ['public', 'followers', 'reacted', 'limited' ], default: 'public' },
+		searchableBy: { type: 'string', enum: ['public', 'followers', 'reacted', 'limited'], default: 'public' },
 	},
 	// (re)note with text, files and poll are optional
 	if: {

--- a/packages/frontend/src/components/MkScheduledNoteDelete.vue
+++ b/packages/frontend/src/components/MkScheduledNoteDelete.vue
@@ -53,7 +53,7 @@
 		}>();
 
 	const expiration = ref('at');
-	const atDate = ref(formatDateTimeString(addTime(new Date(), 1, 'day'), 'yyyy-MM-dd'));
+	const atDate = ref(formatDateTimeString(addTime(new Date(), 0, 'day'), 'yyyy-MM-dd'));
 	const atTime = ref('00:00');
 	const after = ref(0);
 	const unit = ref('second');
@@ -70,7 +70,9 @@
 
 	function get(): DeleteScheduleEditorModelValue {
 		const calcAt = () => {
-			return new Date(`${atDate.value} ${atTime.value}`).getTime();
+			const dateTimeString = `${atDate.value}T${atTime.value}:00`;
+			const parsedDate = new Date(dateTimeString);
+			return parsedDate.getTime();
 		};
 
 		const calcAfter = () => {
@@ -87,8 +89,6 @@
 				case 'second': return base *= 1000;
 				default: return null;
 			};
-			now.setTime(now.getTime() + base);
-			return now.getTime();
 		};
 
 		return {


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
ノートの自動削除で日時指定にすると未来の日付が指定される問題

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
バグ修正

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Update CHANGELOG_CHERRYPICK.md
- [ ] (If possible) Add tests
