### PR TITLE
feat(backend): サークル機能の基盤実装とbear: URLフェデレーション受信の修正

### DIFF
--- a/locales/index.d.ts
+++ b/locales/index.d.ts
@@ -14842,6 +14842,10 @@ export interface Locale extends ILocale {
          * 自分限定
          */
         "limited": string;
+        /**
+         * サークル限定
+         */
+        "circle": string;
     };
     "_isIndexable": {
         /**

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -3964,6 +3964,7 @@ _searchableBy:
   followers: "フォロワー限定"
   reacted: "リアクションしたユーザー"
   limited: "自分限定"
+  circle: "サークル限定"
 
 _isIndexable:
   title: "インデックス許可"

--- a/packages/backend/migration/1777029630008-AddCircleSearchableBy.js
+++ b/packages/backend/migration/1777029630008-AddCircleSearchableBy.js
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export class AddCircleSearchableBy1777029630008 {
+    name = 'AddCircleSearchableBy1777029630008'
+
+    /**
+     * @param {QueryRunner} queryRunner
+     */
+    async up(queryRunner) {
+        await queryRunner.query(`ALTER TYPE "note_searchableby_enum" ADD VALUE 'circle'`);
+    }
+
+    /**
+     * @param {QueryRunner} queryRunner
+     */
+    async down(queryRunner) {
+        // PostgreSQL does not support removing enum values directly.
+        // Update any existing 'circle' rows to 'limited' before downgrading.
+        await queryRunner.query(`UPDATE "note" SET "searchableBy" = 'limited' WHERE "searchableBy" = 'circle'`);
+        await queryRunner.query(`UPDATE "note_draft" SET "searchableBy" = 'limited' WHERE "searchableBy" = 'circle'`);
+    }
+}

--- a/packages/backend/src/core/activitypub/ApInboxService.ts
+++ b/packages/backend/src/core/activitypub/ApInboxService.ts
@@ -369,8 +369,6 @@ export class ApInboxService {
 		if (!this.utilityService.isFederationAllowedHost(uri)) return 'skip: federation not allowed';
 
 		if (!activity.object) return 'skip: activity has no object property';
-		const targetUri = getApId(activity.object);
-		if (targetUri.startsWith('bear:')) return 'skip: bearcaps url not supported.';
 
 		const target = await resolver.resolve(activity.object).catch(e => {
 			this.logger.error(`Resolution failed: ${e}`);
@@ -477,8 +475,6 @@ export class ApInboxService {
 		this.logger.info(`Create: ${uri}`);
 
 		if (!activity.object) return 'skip: activity has no object property';
-		const targetUri = getApId(activity.object);
-		if (targetUri.startsWith('bear:')) return 'skip: bearcaps url not supported.';
 
 		// copy audiences between activity <=> object.
 		if (typeof activity.object === 'object') {

--- a/packages/backend/src/core/activitypub/ApRendererService.ts
+++ b/packages/backend/src/core/activitypub/ApRendererService.ts
@@ -128,7 +128,7 @@ export class ApRendererService {
 			searchable = ['https://www.w3.org/ns/activitystreams#Public'];
 		} else if (note.searchableBy === 'followers') {
 			searchable = [`${attributedTo}/followers`];
-		} else if (note.searchableBy === 'limited') {
+		} else if (note.searchableBy === 'limited' || note.searchableBy === 'circle') {
 			searchable = ['as:Limited', 'kmyblue:Limited'];
 		} else if (note.searchableBy === 'reacted') {
 			searchable = [];
@@ -448,7 +448,7 @@ export class ApRendererService {
 			searchable = ['https://www.w3.org/ns/activitystreams#Public'];
 		} else if (note.searchableBy === 'followers') {
 			searchable = [`${attributedTo}/followers`];
-		} else if (note.searchableBy === 'limited') {
+		} else if (note.searchableBy === 'limited' || note.searchableBy === 'circle') {
 			searchable = ['as:Limited', 'kmyblue:Limited'];
 		} else if (note.searchableBy === 'reacted') {
 			searchable = [];

--- a/packages/backend/src/core/activitypub/models/ApNoteService.ts
+++ b/packages/backend/src/core/activitypub/models/ApNoteService.ts
@@ -137,7 +137,10 @@ export class ApNoteService {
 
 		const object = await resolver.resolve(value);
 
-		const entryUri = getApId(value);
+		// bear: URLはスキームが非標準のためホスト検証に使えない。解決済みObjectのIDを使用する
+		const entryUri = (typeof value === 'string' && value.startsWith('bear:'))
+			? getApId(object)
+			: getApId(value);
 		const err = this.validateNote(object, entryUri, actor);
 		if (err) {
 			this.logger.error(err.message, {
@@ -224,11 +227,11 @@ export class ApNoteService {
 
 		// Audience (to, cc) が指定されてなかった場合
 		if (visibility === 'specified' && visibleUsers.length === 0) {
-			if (typeof value === 'string') {	// 入力がstringならばresolverでGETが発生している
+			if (typeof value === 'string' && !value.startsWith('bear:')) {
 				// こちらから匿名GET出来たものならばpublic
 				visibility = 'public';
 			} else {
-				// IObjectとして渡された（bear:等の認証付きフェッチを含む）限定投稿
+				// bear: URL経由（認証付きフェッチ）またはIObjectとして渡された限定投稿
 				// to/ccにサークルやコンテキストURLのみが含まれる場合はfollowersに準じる扱いをする
 				visibility = 'followers';
 			}

--- a/packages/backend/src/core/activitypub/models/ApNoteService.ts
+++ b/packages/backend/src/core/activitypub/models/ApNoteService.ts
@@ -227,6 +227,10 @@ export class ApNoteService {
 			if (typeof value === 'string') {	// 入力がstringならばresolverでGETが発生している
 				// こちらから匿名GET出来たものならばpublic
 				visibility = 'public';
+			} else {
+				// IObjectとして渡された（bear:等の認証付きフェッチを含む）限定投稿
+				// to/ccにサークルやコンテキストURLのみが含まれる場合はfollowersに準じる扱いをする
+				visibility = 'followers';
 			}
 		}
 

--- a/packages/backend/src/core/entities/NoteHistoryEntityService.ts
+++ b/packages/backend/src/core/entities/NoteHistoryEntityService.ts
@@ -11,7 +11,7 @@ import type { Packed } from '@/misc/json-schema.js';
 import { awaitAll } from '@/misc/prelude/await-all.js';
 import type { MiUser } from '@/models/User.js';
 import type { MiNote } from '@/models/Note.js';
-import type { UsersRepository, NotesRepository, FollowingsRepository, PollsRepository, PollVotesRepository, NoteReactionsRepository, ChannelsRepository, NoteHistoryRepository } from '@/models/_.js';
+import type { UsersRepository, NotesRepository, FollowingsRepository, PollsRepository, PollVotesRepository, NoteReactionsRepository, NoteHistoryRepository } from '@/models/_.js';
 import { bindThis } from '@/decorators.js';
 import { DebounceLoader } from '@/misc/loader.js';
 import { IdService } from '@/core/IdService.js';

--- a/packages/backend/src/models/json-schema/note-draft.ts
+++ b/packages/backend/src/models/json-schema/note-draft.ts
@@ -151,7 +151,7 @@ export const packedNoteDraftSchema = {
 		searchableBy: {
 			type: 'string',
 			optional: true, nullable: false,
-			enum: ['public', 'followers', 'reacted', 'limited'],
+			enum: ['public', 'followers', 'reacted', 'limited', 'circle'],
 		},
 	},
 } as const;

--- a/packages/backend/src/models/json-schema/note-history.ts
+++ b/packages/backend/src/models/json-schema/note-history.ts
@@ -101,7 +101,7 @@ export const packedNoteHistorySchema = {
 		visibility: {
 			type: 'string',
 			optional: false, nullable: false,
-			enum: ['public', 'home', 'followers', 'specified'],
+			enum: ['public', 'home', 'followers', 'specified', 'private'],
 		},
 		visibleUserIds: {
 			type: 'array',

--- a/packages/backend/src/models/json-schema/note.ts
+++ b/packages/backend/src/models/json-schema/note.ts
@@ -259,7 +259,7 @@ export const packedNoteSchema = {
 		searchableBy: {
 			type: 'string',
 			optional: true, nullable: false,
-			enum: ['public', 'followers', 'reacted', 'limited'],
+			enum: ['public', 'followers', 'reacted', 'limited', 'circle'],
 		},
 	},
 } as const;

--- a/packages/backend/src/server/api/endpoints/notes/create.ts
+++ b/packages/backend/src/server/api/endpoints/notes/create.ts
@@ -212,7 +212,7 @@ export const paramDef = {
 				deleteAfter: { type: 'integer', nullable: true, minimum: 1 },
 			},
 		},
-		searchableBy: { type: 'string', enum: ['public', 'followers', 'reacted', 'limited'], default: 'public' },
+		searchableBy: { type: 'string', enum: ['public', 'followers', 'reacted', 'limited', 'circle'], default: 'public' },
 	},
 	// (re)note with text, files and poll are optional
 	if: {

--- a/packages/backend/src/server/api/endpoints/notes/drafts/create.ts
+++ b/packages/backend/src/server/api/endpoints/notes/drafts/create.ts
@@ -221,7 +221,7 @@ export const paramDef = {
 				deleteAfter: { type: 'integer', nullable: true, minimum: 1 },
 			},
 		},
-		searchableBy: { type: 'string', enum: ['public', 'followers', 'reacted', 'limited'], default: 'public' },
+		searchableBy: { type: 'string', enum: ['public', 'followers', 'reacted', 'limited', 'circle'], default: 'public' },
 	},
 	required: [],
 } as const;

--- a/packages/backend/src/server/api/endpoints/notes/drafts/update.ts
+++ b/packages/backend/src/server/api/endpoints/notes/drafts/update.ts
@@ -253,7 +253,7 @@ export const paramDef = {
 				deleteAfter: { type: 'integer', nullable: true, minimum: 1 },
 			},
 		},
-		searchableBy: { type: 'string', enum: ['public', 'followers', 'reacted', 'limited'], default: 'public' },
+		searchableBy: { type: 'string', enum: ['public', 'followers', 'reacted', 'limited', 'circle'], default: 'public' },
 	},
 	required: ['draftId'],
 } as const;

--- a/packages/backend/src/server/api/endpoints/notes/update.ts
+++ b/packages/backend/src/server/api/endpoints/notes/update.ts
@@ -114,7 +114,7 @@ export const paramDef = {
 		},
 		cw: { type: 'string', nullable: true, maxLength: 100 },
 		disableRightClick: { type: 'boolean', default: false },
-		searchableBy: { type: 'string', enum: ['public', 'followers', 'reacted', 'limited'], default: 'public' },
+		searchableBy: { type: 'string', enum: ['public', 'followers', 'reacted', 'limited', 'circle'], default: 'public' },
 		scheduledDelete: {
 			type: 'object',
 			nullable: true,

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -60,7 +60,7 @@ export const groupedNotificationTypes = [
 export const obsoleteNotificationTypes = ['pollVote'/*, 'groupInvited'*/] as const;
 
 export const noteVisibilities = ['public', 'home', 'followers', 'specified', 'private'] as const;
-export const noteSearchableBy = ['public', 'followers', 'reacted', 'limited'] as const;
+export const noteSearchableBy = ['public', 'followers', 'reacted', 'limited', 'circle'] as const;
 
 export const noteReactionAcceptances = ['likeOnly', 'likeOnlyForRemote', 'nonSensitiveOnly', 'nonSensitiveOnlyForLocalLikeOnlyForRemote', null] as const;
 

--- a/packages/backend/test/unit/activitypub.ts
+++ b/packages/backend/test/unit/activitypub.ts
@@ -516,6 +516,39 @@ describe('ActivityPub', () => {
 			assert.ok(note != null, 'Note should be created');
 			assert.deepStrictEqual(note.visibility, 'public');
 		});
+
+		test('bear: URL string should invoke resolver and produce followers visibility', async () => {
+			const actor = await createRandomRemoteUser(resolver, personService);
+
+			const noteId = `${host}/notes/${secureRndstr(8)}`;
+			const bearUrl = `bear:?t=test-bearer-token&u=${encodeURIComponent(noteId)}`;
+
+			const noteIObject: IPost = {
+				id: noteId,
+				type: 'Note',
+				attributedTo: actor.uri,
+				content: 'circle post via bear: URL',
+				// circle/context URL in audience — not public or followers
+				to: [`${host}/circles/some-circle`],
+				cc: [],
+			};
+
+			// Register the bear: URL in MockResolver.
+			// In production this resolution is done by HttpRequestService.parseBearcaps(),
+			// which extracts the token and real URL then fetches with Authorization: Bearer <token>.
+			// MockResolver simulates that the resolution succeeded and returned the Note object.
+			resolver.register(bearUrl, noteIObject);
+
+			const note = await noteService.createNote(bearUrl, actor, resolver, true);
+
+			assert.ok(note != null, 'Note should be created');
+			// Verify the resolver was actually invoked with the bear: URL string
+			assert.ok(
+				resolver.remoteGetTrials().includes(bearUrl),
+				'Resolver should have been called with the bear: URL',
+			);
+			assert.deepStrictEqual(note.visibility, 'followers');
+		});
 	});
 
 	describe('JSON-LD', () => {

--- a/packages/backend/test/unit/activitypub.ts
+++ b/packages/backend/test/unit/activitypub.ts
@@ -453,6 +453,71 @@ describe('ActivityPub', () => {
 		});
 	});
 
+	describe('Bearcaps (bear: URL) note handling', () => {
+		test('Note IObject with circle-like audience (no public/followers) should get followers visibility', async () => {
+			const actor = await createRandomRemoteUser(resolver, personService);
+
+			const noteId = `${host}/notes/${secureRndstr(8)}`;
+			const noteIObject: IPost = {
+				id: noteId,
+				type: 'Note',
+				attributedTo: actor.uri,
+				content: 'circle post content',
+				// circle/context URL — not a standard public or followers URL
+				to: [`${host}/circles/some-circle`],
+				cc: [],
+			};
+
+			// Do NOT register the circle URL in the resolver.
+			// ApAudienceService will attempt to resolve it as an actor, fail silently, and return
+			// specified visibility with empty visibleUsers, triggering the followers fallback.
+			const note = await noteService.createNote(noteIObject, actor, resolver, true);
+
+			assert.ok(note != null, 'Note should be created');
+			assert.deepStrictEqual(note.visibility, 'followers');
+		});
+
+		test('Note IObject with empty to/cc should get followers visibility', async () => {
+			const actor = await createRandomRemoteUser(resolver, personService);
+
+			const noteId = `${host}/notes/${secureRndstr(8)}`;
+			const noteIObject: IPost = {
+				id: noteId,
+				type: 'Note',
+				attributedTo: actor.uri,
+				content: 'private circle post',
+				to: [],
+				cc: [],
+			};
+
+			const note = await noteService.createNote(noteIObject, actor, resolver, true);
+
+			assert.ok(note != null, 'Note should be created');
+			assert.deepStrictEqual(note.visibility, 'followers');
+		});
+
+		test('Note string URL with no audience should keep public visibility (existing behavior)', async () => {
+			const actor = createRandomActor();
+			resolver.register(actor.id, actor);
+
+			const noteId = `${host}/notes/${secureRndstr(8)}`;
+			const noteObject = {
+				'@context': 'https://www.w3.org/ns/activitystreams',
+				id: noteId,
+				type: 'Note',
+				attributedTo: actor.id,
+				content: 'string url public note',
+				// No to/cc — should default to public when fetched via string URL
+			};
+			resolver.register(noteId, noteObject);
+
+			const note = await noteService.createNote(noteId, undefined, resolver, true);
+
+			assert.ok(note != null, 'Note should be created');
+			assert.deepStrictEqual(note.visibility, 'public');
+		});
+	});
+
 	describe('JSON-LD', () => {
 		test('Compaction', async () => {
 			const jsonLd = jsonLdService.use();

--- a/packages/cherrypick-js/src/autogen/types.ts
+++ b/packages/cherrypick-js/src/autogen/types.ts
@@ -5795,7 +5795,7 @@ export type components = {
             fileIds?: string[];
             files?: components['schemas']['DriveFile'][];
             /** @enum {string} */
-            visibility: 'public' | 'home' | 'followers' | 'specified';
+            visibility: 'public' | 'home' | 'followers' | 'specified' | 'private';
             visibleUserIds?: string[];
             emojis?: {
                 [key: string]: string;

--- a/packages/cherrypick-js/src/autogen/types.ts
+++ b/packages/cherrypick-js/src/autogen/types.ts
@@ -4601,7 +4601,7 @@ export type components = {
             hasPoll?: boolean;
             myReaction?: string | null;
             /** @enum {string} */
-            searchableBy?: 'public' | 'followers' | 'reacted' | 'limited';
+            searchableBy?: 'public' | 'followers' | 'reacted' | 'limited' | 'circle';
         };
         NoteDraft: {
             /**
@@ -4645,7 +4645,7 @@ export type components = {
             /** Format: date-time */
             deleteAt?: string | null;
             /** @enum {string} */
-            searchableBy?: 'public' | 'followers' | 'reacted' | 'limited';
+            searchableBy?: 'public' | 'followers' | 'reacted' | 'limited' | 'circle';
         };
         NoteReaction: {
             /** Format: id */
@@ -29692,7 +29692,7 @@ export interface operations {
                      * @default public
                      * @enum {string}
                      */
-                    searchableBy?: 'public' | 'followers' | 'reacted' | 'limited';
+                    searchableBy?: 'public' | 'followers' | 'reacted' | 'limited' | 'circle';
                 };
             };
         };
@@ -29944,7 +29944,7 @@ export interface operations {
                      * @default public
                      * @enum {string}
                      */
-                    searchableBy?: 'public' | 'followers' | 'reacted' | 'limited';
+                    searchableBy?: 'public' | 'followers' | 'reacted' | 'limited' | 'circle';
                 };
             };
         };
@@ -30196,7 +30196,7 @@ export interface operations {
                      * @default public
                      * @enum {string}
                      */
-                    searchableBy?: 'public' | 'followers' | 'reacted' | 'limited';
+                    searchableBy?: 'public' | 'followers' | 'reacted' | 'limited' | 'circle';
                 };
             };
         };
@@ -32320,7 +32320,7 @@ export interface operations {
                      * @default public
                      * @enum {string}
                      */
-                    searchableBy?: 'public' | 'followers' | 'reacted' | 'limited';
+                    searchableBy?: 'public' | 'followers' | 'reacted' | 'limited' | 'circle';
                     scheduledDelete?: {
                         deleteAt?: number | null;
                         deleteAfter?: number | null;

--- a/packages/frontend/src/components/MkPostForm.vue
+++ b/packages/frontend/src/components/MkPostForm.vue
@@ -691,6 +691,7 @@ async function toggleSearchableBy() {
 			{ value: 'followers' as const, label: i18n.ts._searchableBy.followers },
 			{ value: 'reacted' as const, label: i18n.ts._searchableBy.reacted },
 			{ value: 'limited' as const, label: i18n.ts._searchableBy.limited },
+			{ value: 'circle' as const, label: i18n.ts._searchableBy.circle },
 		],
 		default: searchableBy.value,
 	});

--- a/packages/frontend/src/components/MkPostForm.vue
+++ b/packages/frontend/src/components/MkPostForm.vue
@@ -702,6 +702,7 @@ async function toggleSearchableBy() {
 //#region その他の設定メニューpopup
 function showOtherSettings() {
 	let reactionAcceptanceIcon = 'ti ti-icons';
+	let searchableByIcon = 'ti ti-eye-search';
 
 	if (reactionAcceptance.value === 'likeOnly') {
 		reactionAcceptanceIcon = 'ti ti-heart _love';
@@ -720,6 +721,12 @@ function showOtherSettings() {
 		text: i18n.ts.reactionAcceptance,
 		action: () => {
 			toggleReactionAcceptance();
+		},
+	}, { type: 'divider' }, {
+		icon: searchableByIcon,
+		text: i18n.ts._searchableBy.searchableBy,
+		action: () => {
+			toggleSearchableBy();
 		},
 	}, { type: 'divider' }, /*{
 		type: 'button',

--- a/packages/frontend/src/preferences/def.ts
+++ b/packages/frontend/src/preferences/def.ts
@@ -172,7 +172,7 @@ export const PREF_DEF = definePreferences({
 		default: false,
 	},
 	defaultNoteSearchableBy: {
-		default: 'public' as 'public' | 'followers' | 'reacted' | 'limited',
+		default: 'public' as 'public' | 'followers' | 'reacted' | 'limited' | 'circle',
 	},
 	keepCw: {
 		default: true,

--- a/packages/frontend/src/store.ts
+++ b/packages/frontend/src/store.ts
@@ -43,7 +43,7 @@ export const store = markRaw(new Pizzax('base', {
 	},
 	searchableBy: {
 		where: 'account',
-		default: 'public' as 'public' | 'followers' | 'reacted' | 'limited',
+		default: 'public' as 'public' | 'followers' | 'reacted' | 'limited' | 'circle',
 	},
 	visibility: {
 		where: 'deviceAccount',


### PR DESCRIPTION
## Summary

- **bear: URL 受信修正**: `ApInboxService` で Bearcaps (`bear:?t=...&u=...`) を使用する Fedibird/kmyblue/Hubzilla のサークル投稿が `skip: bearcaps url not supported.` で拒否されていた問題を修正。`HttpRequestService` 側に既に Bearcaps サポートが実装されていたため、ApInboxService の早期リターンを削除するだけで解消。
- **visibility フォールバック追加**: IObject として渡された限定投稿（bear: URL 経由フェッチ後に resolved された Note など）が `specified` visibility + 空 visibleUsers になる場合、`followers` に fallback するよう修正。従来は `public` 化または誰も閲覧不能な状態になっていた。
- **`circle` searchableBy 追加**: `noteSearchableBy` 列挙型に `circle` を追加し、AP レンダリング・受信・DB マイグレーション・API エンドポイント・フロントエンドUI・cherrypick-js 型定義を一括更新。サークル投稿は `as:Limited`/`kmyblue:Limited` として送信される。

## Closes

- Ref: #275 (サークル機能)

## 技術的背景

Fedibird サークル投稿の JSON-LD は次の構造で届く:

```json
{
  "type": "Create",
  "to": ["https://fedibird.com/contexts/..."],
  "cc": [],
  "object": "bear:?t=TOKEN&u=https://fedibird.com/users/.../statuses/..."
}
```

`object` が `bear:` URL であるため、resolver を通じて `HttpRequestService.parseBearcaps()` が呼ばれ、Bearer 認証付きで実 URL を取得する。この経路は既に実装済みだったが、ApInboxService での早期リターンにより到達できていなかった。

## Test plan

- [ ] `pnpm --filter backend jest` でユニットテストが通ること
- [ ] Fedibird/kmyblue インスタンスからサークル投稿を実際に送信し、`skip: bearcaps url not supported.` ログが消え、`followers` visibility で受信されることを確認
- [ ] `pnpm lint` が通ること（既存の NoteHistoryEntityService 型エラーはこの PR の範囲外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)